### PR TITLE
[cfn] Extract SSH CIDR block to param

### DIFF
--- a/cloudformation/src/cloudformation/instance.rb
+++ b/cloudformation/src/cloudformation/instance.rb
@@ -136,7 +136,7 @@ resource "CogInstanceIngressSSH", :Type => "AWS::EC2::SecurityGroupIngress", :Pr
   :FromPort => 22,
   :ToPort => 22,
   :IpProtocol => 6,
-  :CidrIp => "0.0.0.0/0"
+  :CidrIp => ref("SshCidrBlock")
 }
 
 resource "CogInstanceIngressAPIs", :Type => "AWS::EC2::SecurityGroupIngress", :Properties => {

--- a/cloudformation/src/cloudformation/parameters.rb
+++ b/cloudformation/src/cloudformation/parameters.rb
@@ -6,7 +6,7 @@
 # Required AWS Configuration
 #
 
-aws_params = %w(VpcId SubnetIds KeyName InstanceType ImageId)
+aws_params = %w(VpcId SubnetIds KeyName SshCidrBlock InstanceType ImageId)
 
 parameter "VpcId",
   :Description => "VPC ID for Cog deployment",
@@ -18,6 +18,12 @@ parameter "KeyName",
   :Description => "Name of an existing EC2 KeyPair to enable SSH access",
   :Type => "AWS::EC2::KeyPair::KeyName",
   :ConstraintDescription => "must be the name of an existing EC2 KeyPair"
+
+parameter "SshCidrBlock",
+  :Description => "The CIDR block from which to allow SSH access",
+  :Type => "String",
+  :Default => "0.0.0.0/0",
+  :ConstraintDescription => "must be a CIDR block"
 
 parameter "InstanceType",
   :Description => "Cog Host EC2 instance type",

--- a/cloudformation/templates/cloudformation.json
+++ b/cloudformation/templates/cloudformation.json
@@ -13,6 +13,12 @@
       "Type": "AWS::EC2::KeyPair::KeyName",
       "ConstraintDescription": "must be the name of an existing EC2 KeyPair"
     },
+    "SshCidrBlock": {
+      "Description": "The CIDR block from which to allow SSH access",
+      "Type": "String",
+      "Default": "0.0.0.0/0",
+      "ConstraintDescription": "must be a CIDR block"
+    },
     "InstanceType": {
       "Description": "Cog Host EC2 instance type",
       "Type": "String",
@@ -383,6 +389,7 @@
             "VpcId",
             "SubnetIds",
             "KeyName",
+            "SshCidrBlock",
             "InstanceType",
             "ImageId"
           ]
@@ -743,7 +750,9 @@
         "FromPort": 22,
         "ToPort": 22,
         "IpProtocol": 6,
-        "CidrIp": "0.0.0.0/0"
+        "CidrIp": {
+          "Ref": "SshCidrBlock"
+        }
       }
     },
     "CogInstanceIngressAPIs": {


### PR DESCRIPTION
This gives users the ability to restrict SSH access to their bastion host(s) IP block.
