### PR TITLE
[cfn] Some RDS features

### DIFF
--- a/cloudformation/src/cloudformation/parameters.rb
+++ b/cloudformation/src/cloudformation/parameters.rb
@@ -80,6 +80,8 @@ parameter "DatabaseSource",
 
 condition "ProvisionRds", equal(ref("DatabaseSource"), "RDS")
 
+condition "HasDBSnapshot", not_equal(ref("RdsSnapshotIdentifier"), "")
+
 ##
 # Cog Database (External)
 #
@@ -100,7 +102,7 @@ parameter "CogDbSsl",
 # Cog Database (RDS)
 #
 
-rds_params = %w(RdsMasterUsername RdsMasterPassword RdsInstanceType RdsStorage RdsBackupRetention RdsMultiAZ)
+rds_params = %w(RdsMasterUsername RdsMasterPassword RdsInstanceType RdsStorage RdsBackupRetention RdsMultiAZ RdsSnapshotIdentifier)
 
 parameter "RdsMasterUsername",
   :Description => "Username for Postgres admin user",
@@ -132,6 +134,11 @@ parameter "RdsMultiAZ",
   :Type => "String",
   :AllowedValues => %w(false true),
   :Default => "false"
+
+parameter "RdsSnapshotIdentifier",
+:Description => "The RDS DB snapshot to restore. Leave blank to create an empty database.",
+:Type => "String",
+:Default => ""
 
 ##
 # Cog Configuration (Bootstrap)

--- a/cloudformation/src/cloudformation/rds.rb
+++ b/cloudformation/src/cloudformation/rds.rb
@@ -74,6 +74,7 @@ resource "RdsIngressPg",
 resource "RdsDatabase",
   :Type => "AWS::RDS::DBInstance",
   :Condition => "ProvisionRds",
+  :DeletionPolicy => "Snapshot",
   :Properties => {
     :AllocatedStorage => ref("RdsStorage"),
     :BackupRetentionPeriod => ref("RdsBackupRetention"),
@@ -86,6 +87,7 @@ resource "RdsDatabase",
     :VPCSecurityGroups => [ ref("RdsSecurityGroup") ],
     :MasterUsername => ref("RdsMasterUsername"),
     :MasterUserPassword => ref("RdsMasterPassword"),
+    :DBSnapshotIdentifier => fn_if("HasDBSnapshot", ref("RdsSnapshotIdentifier"), ref("AWS::NoValue")),
     :Tags => [
       {
         :Key => "Name",

--- a/cloudformation/templates/cloudformation.json
+++ b/cloudformation/templates/cloudformation.json
@@ -431,7 +431,8 @@
             "RdsInstanceType",
             "RdsStorage",
             "RdsBackupRetention",
-            "RdsMultiAZ"
+            "RdsMultiAZ",
+            "RdsSnapshotIdentifier"
           ]
         },
         {
@@ -1199,17 +1200,6 @@
         "DBInstanceClass": {
           "Ref": "RdsInstanceType"
         },
-        "DBSnapshotIdentifier": {
-          "Fn::If": [
-            "HasDBSnapshot",
-            {
-              "Ref": "RdsSnapshotIdentifier"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
         "DBSubnetGroupName": {
           "Ref": "RdsSubnetGroup"
         },
@@ -1228,6 +1218,17 @@
         },
         "MasterUserPassword": {
           "Ref": "RdsMasterPassword"
+        },
+        "DBSnapshotIdentifier": {
+          "Fn::If": [
+            "HasDBSnapshot",
+            {
+              "Ref": "RdsSnapshotIdentifier"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
         },
         "Tags": [
           {

--- a/cloudformation/templates/cloudformation.json
+++ b/cloudformation/templates/cloudformation.json
@@ -118,6 +118,11 @@
       ],
       "Default": "false"
     },
+    "RdsSnapshotIdentifier": {
+      "Description": "The RDS DB snapshot to restore. Leave blank to create an empty database.",
+      "Type": "String",
+      "Default": ""
+    },
     "CogBootstrapInstance": {
       "Description": "Configure Cog admin user automatically with bootstrap settings or manually via cogctl",
       "Type": "String",
@@ -249,6 +254,18 @@
           "Ref": "DatabaseSource"
         },
         "RDS"
+      ]
+    },
+    "HasDBSnapshot": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "RdsSnapshotIdentifier"
+            },
+            ""
+          ]
+        }
       ]
     },
     "CogBootstrapInstance": {
@@ -1181,6 +1198,17 @@
         "DBName": "cog",
         "DBInstanceClass": {
           "Ref": "RdsInstanceType"
+        },
+        "DBSnapshotIdentifier": {
+          "Fn::If": [
+            "HasDBSnapshot",
+            {
+              "Ref": "RdsSnapshotIdentifier"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
         },
         "DBSubnetGroupName": {
           "Ref": "RdsSubnetGroup"

--- a/cloudformation/templates/cloudformation.json
+++ b/cloudformation/templates/cloudformation.json
@@ -1170,6 +1170,7 @@
     "RdsDatabase": {
       "Type": "AWS::RDS::DBInstance",
       "Condition": "ProvisionRds",
+      "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": {
           "Ref": "RdsStorage"


### PR DESCRIPTION
### Add a parameter to restore from an RDS Snapshot

This is feature is handy for disaster recovery, or if you need to
migrate your stack to a different VPC, region, or account.
### Take a snapshot when deleting the database

NB: CloudFormation prohibits [DeletionPolicies](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) from referencing a parameter. Seems better to be safe by default.
