### PR TITLE
[cfn] Allow empty DatabaseUrl (for RDS)

### DIFF
--- a/cloudformation/src/cloudformation/parameters.rb
+++ b/cloudformation/src/cloudformation/parameters.rb
@@ -88,7 +88,8 @@ parameter "DatabaseUrl",
   :Description => "Database connection string for external database",
   :Type => "String",
   :AllowedPattern => "^(ecto://[^:]+:[^@]+@[^/]+/.*)?$",
-  :ConstraintDescription => "must be a valid Cog database URL"
+  :ConstraintDescription => "must be empty or a valid Cog database URL",
+  :Default => ""
 
 parameter "CogDbSsl",
   :Description => "Use SSL to connect to Postgres",

--- a/cloudformation/templates/cloudformation.json
+++ b/cloudformation/templates/cloudformation.json
@@ -73,7 +73,8 @@
       "Description": "Database connection string for external database",
       "Type": "String",
       "AllowedPattern": "^(ecto://[^:]+:[^@]+@[^/]+/.*)?$",
-      "ConstraintDescription": "must be a valid Cog database URL"
+      "ConstraintDescription": "must be empty or a valid Cog database URL",
+      "Default": ""
     },
     "CogDbSsl": {
       "Description": "Use SSL to connect to Postgres",


### PR DESCRIPTION
I think this is a reasonable default since the default `DatabaseSource` is RDS.
