### PR TITLE
[cfn] Add UpdatedPolicy to ASG for updating LaunchConfig

### DIFF
--- a/cloudformation/src/cloudformation/instance.rb
+++ b/cloudformation/src/cloudformation/instance.rb
@@ -176,6 +176,7 @@ output "CogInstanceRole", :Value => get_att("CogInstanceRole", "Arn")
 
 resource "CogAsg",
   :Type => "AWS::AutoScaling::AutoScalingGroup",
+  :UpdatePolicy => { :AutoScalingReplacingUpdate => { :WillReplace => true } },
   :Properties => {
     :VPCZoneIdentifier => ref("SubnetIds"),
     :DesiredCapacity => 1,

--- a/cloudformation/templates/cloudformation.json
+++ b/cloudformation/templates/cloudformation.json
@@ -795,6 +795,11 @@
     },
     "CogAsg": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingReplacingUpdate": {
+          "WillReplace": true
+        }
+      },
       "Properties": {
         "VPCZoneIdentifier": {
           "Ref": "SubnetIds"


### PR DESCRIPTION
When updating the launch config, cloudformation will now create a new ASG to run
the new launch config; then destroy the old ASG.

This avoids a gotcha where you update the launch config; but the
currently running ASG instance doesn’t pick up the changes.

See [here for more details](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html) and other ways of updating the stack.

NB that this approach means there are _two_ ASGs running cog for a brief time. I'm not sure if that's a big problem.

An alternative approach to fix this gotcha is to run the `cfn-hup` command on the ASG instances.
